### PR TITLE
Pin pipelinewise-singer-python to 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='pipelinewise-tap-postgres',
           'Programming Language :: Python :: 3 :: Only'
       ],
       install_requires=[
-          'pipelinewise-singer-python==1.*',
+          'pipelinewise-singer-python==1.3.0',
           'psycopg2-binary==2.8.6',
           'strict-rfc3339==0.7',
       ],


### PR DESCRIPTION
## Problem

From the Meltano Slack https://meltano.slack.com/archives/C01TCRBBJD7/p1637613452243400

Running the tap-postgres extractor results in the following error:

```
import simplejson as json
ModuleNotFoundError: No module named 'simplejson'
```

It looks like the simplejson library has been replaced with orjson in pipelinewise-singer-python 1.4.0 which is breaking the extractor.

## Proposed changes

Pin `pipelinewise-singer-python` to 1.3.0

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
